### PR TITLE
tryout to get cross compilation to work.

### DIFF
--- a/gateway/lambda/Cargo.toml
+++ b/gateway/lambda/Cargo.toml
@@ -6,8 +6,8 @@ version = "0.1.0"
 [dependencies]
 anyhow = "1.0.53"
 apollo-router = { git = "https://github.com/apollographql/router", default-features = false }
-axum = {version = "0.4.4", features = ["headers"]}
-structopt = {version = "0.3.26", default-features = false}
+axum = { version = "0.4.4", features = ["headers"] }
+structopt = { version = "0.3.26", default-features = false }
 lambda-web = { version = "0.1.8", features = ["hyper"] }
 #tracing = "0.1"
 #tracing-subscriber = { version = "0.3.7", features = ["fmt", "json", "env-filter"] }
@@ -20,6 +20,8 @@ directories = "4.0.1"
 futures = "0.3.19"
 #opentelemetry = "0.17.0"
 #opentelemetry-otlp = "0.10.0"
+[target.'cfg(target_arch = "aarch64")'.dependencies]
+openssl-sys = { version = "0.9", features = ["vendored"] }
 
 
 #[patch.crates-io]

--- a/gateway/lambda/Dockerfile
+++ b/gateway/lambda/Dockerfile
@@ -9,10 +9,10 @@ ARG user=graphql
 
 RUN rustup target add $target
 
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && \
+    apt-get install -y \
     musl-tools \
-    musl-dev \
-    libssl-dev
+    musl-dev
 
 RUN update-ca-certificates
 
@@ -33,6 +33,12 @@ RUN adduser \
     --no-create-home \
     --uid "${UID}" \
     "${USER}"
+
+# install aarch64-unknown-linux-musl-cross
+RUN wget https://musl.cc/aarch64-linux-musl-cross.tgz && \
+    tar -xvf aarch64-linux-musl-cross.tgz
+
+ENV PATH=/aarch64-linux-musl-cross/bin:$PATH
 
 WORKDIR /app
 


### PR DESCRIPTION
 currently hitting a hiccup building rusty_v8, which has been documented [here](https://github.com/denoland/rusty_v8/issues/49) and worked around [there](https://gist.github.com/kesor/68df53a5d76784a235ca6b0e7efed4d9)


```
=> => # error: failed to add native library /app/target/aarch64-unknown-linux-musl/release/gn_out/o
=> => # bj/librusty_v8.a: file too small to be an archive                                          
=> => # error: could not compile `v8` due to previous error                                        
=> => # warning: build failed, waiting for other jobs to finish...                                 
```